### PR TITLE
The clusterViewer role is enough to execute get-credentials

### DIFF
--- a/docs/cluster_configuration.md
+++ b/docs/cluster_configuration.md
@@ -79,13 +79,12 @@ There are a couple key points to understand about how Cloud IAM and Kubernetes R
 
     In order for `users` and `service accounts` to perform a `gcloud container clusters get-credentials` call to generate a valid `kubeconfig` for a GKE `cluster`, they need to have the following permissions:
 
-    * `container.apiServices.get`
-    * `container.apiServices.list`
     * `container.clusters.get`
     * `container.clusters.list`
-    * `container.clusters.getCredentials`
+    * `resourcemanager.projects.get`
+    * `resourcemanager.projects.list`
 
-    If these permissions are grouped into a custom IAM `role`, that IAM `role` can be conveniently bound to a Gsuite/Cloud Identity `group` which includes all users that need access to the `cluster`.
+    These permissions are available in the predefined role `roles/container.clusterViewer`, which can be bound to a Gsuite/Cloud Identity `group` which includes all users that need access to the `cluster`.
 
     From this point, the `users` and `service accounts` can be granted access to resources as needed with `cluster`-wide or per-`namespace` granularity.  This has the benefit of minimizing IAM changes needed, ensuring access granted is per-`cluster`, giving the highest granularity, and making troubleshooting permissions an RBAC-only process.
 


### PR DESCRIPTION
GKE provides a predefined IAM role (roles/container.clusterViewer) that is sufficient to execute `gcloud container clusters
get-credentials` against a cluster, assuming that the user is using standard Google authentication against their cluster.

In particular, the `getCredentials` permission is *not* needed unless you are trying to use basic auth or client cert authentication to the cluster, which no one should be doing.  (Client cert, despite its appealing name, refers to a *single*, predefined client cert that was originally used for bootstrapping authentication to a cluster).

For most users, all `gcloud container clusters get-credentials` does is:
  * Fetch the cluster object from the GKE API, and take note of the apiserver's certificate.
  * Write the certificate and the gcloud auth helper into a new kubeconfig entry.

When actually authenticating to the cluster, gcloud will use the configured credential helper to get a Google OAuth access token and send it to the cluster, where the IAM authorizer will verify it.